### PR TITLE
Compress from www dir to fix build

### DIFF
--- a/lib/phonegap-build/create/zip.js
+++ b/lib/phonegap-build/create/zip.js
@@ -36,6 +36,12 @@ module.exports = {
                 return;
             }
 
+            // Phonegap Build expects 'www' to be at the root level in the
+            // ZIP-file - we'll keep the oldDir to CD back after the ZIP's
+            // been created.
+            var oldDir = shell.pwd();
+            shell.cd(wwwPath);
+
             // make build directory
             shell.mkdir('-p', buildPath);
 
@@ -46,13 +52,17 @@ module.exports = {
             var cmd;
 
             if(process.env.OS == "Windows_NT") {
-                cmd = 'wscript '+ path.join('..', '..', '..', 'res', 'windows', 'zip.js') + ' ' + zipPath + ' ' + wwwPath;
+                cmd = 'wscript '+ path.join('..', '..', '..', 'res', 'windows', 'zip.js') + ' ' + zipPath + ' .';
             }
             else {
-                cmd = 'zip -r ' + zipPath + ' ' + wwwPath;
+                cmd = 'zip -r ' + zipPath + ' .';
             }
 
             var out = shell.exec(cmd, { silent: true });
+
+            // Change back to old directory due to implicit assumptions
+            // on the current working directory elsewhere in the script.
+            shell.cd(oldDir);
 
             if (out.code !== 0) {
                 module.exports.cleanup(zipPath);


### PR DESCRIPTION
Before the full local path was contained in the ZIP-file and uploaded as such to PhoneGap Build. Due to a recent change in their machinery, their build script will not traverse the whole directory tree anymore but expects to find index.html in a top-level www directory or in the root of the ZIP-file.

Reference: http://community.phonegap.com/nitobi/topics/error_no_index_html_found-xcvob
